### PR TITLE
Refactor: add XHR params to options argument passed to success/error callbacks

### DIFF
--- a/ng-backbone.js
+++ b/ng-backbone.js
@@ -57,13 +57,25 @@
           params.params = options.data;
         }
 
-        var xhr = options.xhr = ajax(_.extend(params, options)).
-          success(function(data) {
+        var xhr = ajax(_.extend(params, options)).
+          success(function(data, status, headers, config) {
+            options.xhr = {
+              status: status,
+              headers: headers,
+              config: config
+            };
+
             if (!isUndefined(options.success) && _.isFunction(options.success)) {
               options.success(data);
             }
           }).
-          error(function(data) {
+          error(function(data, status, headers, config) {
+            options.xhr = {
+              status: status,
+              headers: headers,
+              config: config
+            };
+
             if (!isUndefined(options.error) && _.isFunction(options.error)) {
               options.error(data);
             }

--- a/test/backbone.spec.js
+++ b/test/backbone.spec.js
@@ -82,6 +82,21 @@ describe('Backbone', function () {
 
       $httpBackend.flush();
     });
+
+    it('should set xhr params on options', function () {
+      $httpBackend.when('GET', '/test').respond(400, {message: 'test is broken'});
+
+      var options = {
+        url: '/test',
+        error: angular.noop
+      };
+
+      Backbone.sync('read', tempModel, options);
+
+      $httpBackend.flush();
+
+      expect(options.xhr.status).toBe(400);
+    });
   });
 
   it('should make a GET request', function () {

--- a/test/ng-backbone-collection.spec.js
+++ b/test/ng-backbone-collection.spec.js
@@ -202,4 +202,29 @@ describe('NgBackboneCollection', function () {
       });
     });
   });
+
+  describe('callbacks', function () {
+    var $httpBackend;
+
+    beforeEach(inject(function (_$httpBackend_) {
+      $httpBackend = _$httpBackend_;
+    }));
+
+    it('Should expose xhr params on the options argument', function (done) {
+      $httpBackend.when('GET', '/get').respond(400);
+
+      error = function (collection, response, options) {
+        expect(options.xhr.status).toBe(400);
+
+        done()
+      }
+
+      collection.fetch({
+        url: '/get',
+        error: error
+      });
+
+      $httpBackend.flush()
+    });
+  });
 });


### PR DESCRIPTION
See https://github.com/adrianlee44/ng-backbone/issues/7

This exposes the HTTP status code and headers on `options.xhr`